### PR TITLE
Use ${BPN} instead of ${PN}

### DIFF
--- a/recipes-devtools/fwup/fwup_0.9.1.bb
+++ b/recipes-devtools/fwup/fwup_0.9.1.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 DEPENDS = "libconfuse libarchive libsodium zlib pkgconfig-native"
 
-SRC_URI = "https://github.com/fhunleth/fwup/releases/download/v${PV}/${PN}-${PV}.tar.gz"
+SRC_URI = "https://github.com/fhunleth/fwup/releases/download/v${PV}/${BPN}-${PV}.tar.gz"
 
 SRC_URI[md5sum] = "81ccbe8c2b31a0714e1587a857aa22f1"
 SRC_URI[sha256sum] = "9ad389c96429e6c29d9c45d145de0e7c04968794864a872ce939933e0ab5f4bd"


### PR DESCRIPTION
This makes sure `fwup-0.9.1.tar.gz` will always be downloaded and not `fwup-native-0.9.1.tar.gz` if `fwup-native` was selected.
