### PR TITLE
fix QA issue by adding bash to RDEPENDS

### DIFF
--- a/recipes-devtools/fwup/fwup_git.bb
+++ b/recipes-devtools/fwup/fwup_git.bb
@@ -5,6 +5,7 @@ SECTION = "devel"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 DEPENDS = "libconfuse libarchive libsodium zlib pkgconfig-native"
+RDEPENDS_${PN} = "bash"
 
 SRC_URI = "git://github.com/fhunleth/fwup.git;protocol=https;"
 


### PR DESCRIPTION
Was unable to build fwup out of the box but the fix is trivial. 