### PR TITLE
Add support for fwup as IMAGE_TYPES

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a Yocto meta layer for building `fwup` into Yocto projects.
 
+## Dependencies:
+
 This layer depends on: 
 
 URI: https://github.com/openembedded/meta-openembedded.git layers: meta-oe branch: master
@@ -17,6 +19,23 @@ BBLAYERS ?= " \
   "
 ```
 
-Or add `IMAGE_INSTALL_append = "fwup"` in `conf/local.conf` and run
+There are two main use cases:
+
+One is to add `IMAGE_INSTALL_append = "fwup"` in `conf/local.conf` and run
 `bitbake core-image-minimal` to get an image with fwup support.
 
+The second one is to add the following configuration in `conf/local.conf`:
+
+```text
+# Add image_types_fwup to the system
+IMAGE_CLASSES += "image_types_fwup"
+
+# Declare that we want to make fwup images
+IMAGE_FSTYPES = "fwup"
+
+# It's mandatory to define a fwup config file format
+FWUP_FILE = "sdimg-raspberrypi0-wifi.fwup"
+```
+
+When running `bitbake core-image-minimal` a .fw image will be created at
+`tmp/deploy/image/<MACHINE NAME>/core-image-minimal-<MACHINE NAME>.rootfs.fw`

--- a/classes/image_types_fwup.bbclass
+++ b/classes/image_types_fwup.bbclass
@@ -1,0 +1,165 @@
+inherit image-artifact-names
+
+# This class relies on wic image class in order to create
+# images for bootloader and root partition without having to
+# dealing with files in this class. Here we are forcing
+# the use of a wks template to avoid the user the needed of
+# providing one. It adds a small build time overhead but decreases
+# the complexity and maintainability.
+WKS_FILE = "sdimage-template.wks"
+
+IMAGE_INSTALL:append = " fwup"
+
+FWUP_META_PRODUCT ?= "${PN}"
+FWUP_META_DESCRIPTION ?= ""
+FWUP_META_VERSION ?= "${PV}"
+FWUP_META_AUTHOR ?= ""
+FWUP_META_PLATFORM ?= "${DISTRO}-${MACHINE}"
+FWUP_META_ARCHITECTURE ?= "${TARGET_ARCH}"
+FWUP_META_VCS_IDENTIFIER ?= ""
+FWUP_META_MISC ?= "${TARGET_VENDOR}"
+FWUP_META_CREATION_DATE ?= "${DATETIME}"
+FWUP_META_UUID ?= ""
+
+# The FWUPVARS variable is used to define list of bitbake variables used in fwup code
+# variables from this list is written to <image>.env file
+FWUPVARS ?= "\
+    FWUP_META_PRODUCT \
+    FWUP_META_DESCRIPTION \
+    FWUP_META_VERSION \
+    FWUP_META_AUTHOR \
+    FWUP_META_PLATFORM \
+    FWUP_META_ARCHITECTURE \
+    FWUP_META_VCS_IDENTIFIER \
+    FWUP_META_CREATION_DATE \
+    FWUP_META_MISC \
+    FWUP_META_UUID \
+"
+
+IMAGE_TYPEDEP:fwup = "ext4 wic"
+
+FWUP_FILE ??= "${IMAGE_BASENAME}.${MACHINE}.fwup"
+FWUP_FILES ?= "${FWUP_FILE} ${IMAGE_BASENAME}.fwup"
+FWUP_SEARCH_PATH ?= "${THISDIR}:${@':'.join('%s/fwup' % p for p in '${BBPATH}'.split(':'))}:${COREBASE}'.split(':'))}"
+FWUP_FULL_PATH = "${@fwup_search(d.getVar('FWUP_FILES').split(), d.getVar('FWUP_SEARCH_PATH')) or ''}"
+
+def fwup_search(files, search_path):
+    for f in files:
+        if os.path.isabs(f):
+            if os.path.exists(f):
+                return f
+        else:
+            searched = bb.utils.which(search_path, f)
+            if searched:
+                return searched
+
+IMAGE_CMD:fwup () {
+	out="${IMGDEPLOYDIR}/${IMAGE_NAME}"
+	build_fwup="${WORKDIR}/build-fwup"
+    fwup="${FWUP_FULL_PATH}"
+	if [ -z "$fwup" ]; then
+		bbfatal "No fwup files from FWUP_FILES were found: ${FWUP_FILES}. Please set FWUP_FILE or FWUP_FILES appropriately."
+	fi
+
+    # load additional variables for fwup purposes
+    . $build_fwup/fwup.env
+
+    PSEUDO_UNLOAD=1 fwup -v -c -o "$build_fwup/${IMAGE_BASENAME}.fw" -f "$fwup"
+
+	mv "$build_fwup/${IMAGE_BASENAME}.fw" "$out.fw"
+
+    cd ${IMGDEPLOYDIR}
+    ln -sf ${IMAGE_NAME}.fw ${IMAGE_LINK_NAME}.fw
+}
+
+addtask do_image_fwup after do_image_wic
+
+IMAGE_CMD:fwup[vardepsexclude] = "FWUP_FULL_PATH FWUP_FILES TOPDIR"
+
+# Rebuild when the fwup file or vars in FWUPVARS change
+USING_FWUP = "${@bb.utils.contains_any('IMAGE_FSTYPES', 'fwup ' + ' '.join('fwup.%s' % c for c in '${CONVERSIONTYPES}'.split()), '1', '', d)}"
+FWUP_FILE_CHECKSUM = "${@'${FWUP_FULL_PATH}:%s' % os.path.exists('${FWUP_FULL_PATH}') if '${USING_FWUP}' else ''}"
+do_image_fwup[file-checksums] += "${FWUP_FILE_CHECKSUM}"
+
+do_image_fwup[depends] += "fwup-native:do_populate_sysroot"
+
+FWUP_FILE_DEPENDS = "fwup-native"
+
+DEPENDS += "${@ '${FWUP_FILE_DEPENDS}' if d.getVar('USING_FWUP') else '' }"
+
+def get_first_file(globs, root_dir):
+    """Return first file found in wildcard globs"""
+    import glob
+    for g in globs:
+        all_files = glob.glob(g, root_dir=root_dir)
+        if all_files:
+            for f in all_files:
+                if not os.path.isdir(f):
+                    return f
+    return None
+
+def calculate_size_blocks(d, image_file):
+    block_size = 512
+
+    data_size_blocks, data_size_rest = divmod(os.stat(image_file).st_size, block_size)
+    data_blocks = data_size_blocks + (1 if data_size_rest else 0)
+    data_size = data_blocks * block_size
+
+    bb.debug(1, f"the file {image_file} has data_size {data_size} data_size_blocks: {data_size_blocks}, {data_size_rest}")
+
+    return data_blocks
+
+python do_fwup_conf () {
+    fwupvars = d.getVar('FWUPVARS')
+    if not fwupvars:
+        return
+
+    build_wic = os.path.join(d.getVar('WORKDIR'), 'build-wic')
+    build_fwup = os.path.join(d.getVar('WORKDIR'), 'build-fwup')
+
+    wks_file = d.getVar('WKS_FULL_PATH')
+    wks_file_basename = os.path.basename(wks_file).rsplit('.', 1)[0]
+
+    glob_bootloader = "%s-*-*.p1" % wks_file_basename
+    glob_rootfs = "%s-*-*.p2" % wks_file_basename
+
+    bootloader = get_first_file([glob_bootloader], build_wic)
+    if not bootloader:
+        bb.fatal("no glob %s in %s: '%s'" % (glob_bootloader, build_wic, bootloader))
+
+    rootfs = get_first_file([glob_rootfs], build_wic)
+    if not rootfs:
+        bb.fatal("no glob %s in %s: '%s'" % (glob_rootfs, build_wic, rootfs))
+
+    bootloader_img = os.path.join(build_wic, bootloader)
+    rootfs_img = os.path.join(build_wic, rootfs)
+
+    bb.debug(1, f"boot {bootloader_img} img {rootfs_img}")
+
+    fwup_env_filename = os.path.join(build_fwup, "fwup.env")
+
+    fwup_resources = {
+        "FWUP_BOOTLOADER_IMG": bootloader_img,
+        "FWUP_BOOTLOADER_IMG_BLOCKS": calculate_size_blocks(d, bootloader_img),
+        "FWUP_ROOTFS_IMG": rootfs_img,
+        "FWUP_ROOTFS_IMG_BLOCKS": calculate_size_blocks(d, rootfs_img)
+    }
+
+    with open(fwup_env_filename, 'w') as conf:
+        for var in fwupvars.split():
+            value = d.getVar(var)
+            if value:
+                #final_var = var.replace("FWUP_", "").lower().replace("_", "-")
+                conf.write('export %s="%s"\n' % (var, value.strip()))
+
+        for resource, imgfile in fwup_resources.items():
+            conf.write('export %s="%s"\n' % (resource, imgfile))
+
+    conf.close()
+}
+addtask do_fwup_conf after do_image_wic before do_image_fwup
+do_fwup_conf[cleandirs] = "${WORKDIR}/build-fwup"
+# do_fwup_conf[vardeps] += "${FWUPVARS}"
+# do_fwup_conf[vardepsexclude] += "FWUP_META_CREATION_DATE"
+
+IMAGE_TYPES += " fwup"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_fwup-layer = "7"
 LAYERDEPENDS_fwup-layer = "core"
 LAYERDEPENDS_fwup-layer += "openembedded-layer"
 
-LAYERSERIES_COMPAT_fwup-layer = "kirkstone"
+LAYERSERIES_COMPAT_fwup-layer = "kirkstone scarthgap"

--- a/fwup/sdimg-raspberrypi0-wifi.fwup
+++ b/fwup/sdimg-raspberrypi0-wifi.fwup
@@ -1,0 +1,367 @@
+# Firmware configuration file for the Raspberry Pi0
+#
+# Adapt from https://github.com/nerves-project/nerves_system_rpi0/blob/main/fwup.conf
+# for Yocto/OE purposes.
+
+require-fwup-version="0.15.0"  # For the trim() call
+
+# All of these can be overriden using environment variables of the same name.
+#
+#  Run 'fwup -m' to query values in a .fw file.
+#  Use 'fw_printenv' to query values on the target.
+#
+# The image_types_fwup class from meta-fwup Yocto layer provides additional
+# variables. Here is some of them:
+# 
+# - FWUP_BOOTLOADER_IMG: final bootloader image, ready to write
+# - FWUP_BOOTLOADER_IMG_BLOCKS: bootloader image in blocks (512 bytes)
+# - FWUP_ROOTFS_IMG: final rootfs image, ready to write
+# - FWUP_ROOTFS_IMG_BLOCKS: rootfs image in blocks (512 bytes)
+#
+# These are used by Nerves libraries to introspect.
+define(NERVES_FW_PRODUCT, "Nerves Firmware")
+define(NERVES_FW_DESCRIPTION, "")
+define(NERVES_FW_VERSION, "${NERVES_SDK_VERSION}")
+define(NERVES_FW_PLATFORM, "rpi0")
+define(NERVES_FW_ARCHITECTURE, "arm")
+define(NERVES_FW_AUTHOR, "The Nerves Team")
+
+define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
+define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p3") # Linux part number is 1-based
+define(NERVES_FW_APPLICATION_PART0_FSTYPE, "ext4")
+define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
+#define(NERVES_PROVISIONING, "${NERVES_SYSTEM}/images/fwup_include/provisioning.conf")
+
+# Default paths if not specified via the commandline
+#define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
+
+# This configuration file will create an image that has an MBR and the
+# following 3 partitions:
+#
+# +----------------------------+
+# | MBR                        |
+# +----------------------------+
+# | Firmware configuration data|
+# | (formatted as uboot env)   |
+# +----------------------------+
+# | p0*: Boot A (FAT32)        |
+# | zImage, bootcode.bin,      |
+# | config.txt, etc.           |
+# +----------------------------+
+# | p0*: Boot B (FAT32)        |
+# +----------------------------+
+# | p1*: Rootfs A (squashfs)   |
+# +----------------------------+
+# | p1*: Rootfs B (squashfs)   |
+# +----------------------------+
+# | p2: Application (ext4)     |
+# +----------------------------+
+#
+# The p0/p1 partition points to whichever of configurations A or B that is
+# active.
+#
+# The image is sized to be less than 1 GB so that it fits on nearly any SDCard
+# around. If you have a larger SDCard and need more space, feel free to bump
+# the partition sizes below.
+
+# The Raspberry Pi is incredibly picky on the partition sizes and in ways that
+# I don't understand. Test changes one at a time to make sure that they boot.
+# (Sizes are in 512 byte blocks)
+define(UBOOT_ENV_OFFSET, 16)
+define(UBOOT_ENV_COUNT, 16)  # 8 KB
+
+define(BOOT_A_PART_OFFSET, 63)
+define(BOOT_A_PART_COUNT, ${FWUP_BOOTLOADER_IMG_BLOCKS})
+define-eval(BOOT_B_PART_OFFSET, "${BOOT_A_PART_OFFSET} + ${BOOT_A_PART_COUNT}")
+define(BOOT_B_PART_COUNT, ${BOOT_A_PART_COUNT})
+
+define-eval(ROOTFS_A_PART_OFFSET, "${BOOT_B_PART_OFFSET} + ${BOOT_B_PART_COUNT}")
+define(ROOTFS_A_PART_COUNT, ${FWUP_ROOTFS_IMG_BLOCKS})
+define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
+define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
+
+# Application partition. This partition can occupy all of the remaining space.
+# Size it to fit the destination.
+define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
+define(APP_PART_COUNT, 1048576)
+
+# Firmware archive metadata
+meta-product = ${FWUP_META_PRODUCT}
+meta-description = ${FWUP_META_DESCRIPTION}
+meta-version = ${FWUP_META_VERSION}
+meta-platform = ${FWUP_META_PLATFORM}
+meta-architecture = ${FWUP_META_ARCHITECTURE}
+meta-author = ${FWUP_META_FW_AUTHOR}
+meta-vcs-identifier = ${FWUP_META_VCS_IDENTIFIER}
+meta-creation-date = ${FWUP_META_CREATION_DATE}
+meta-misc = "${FWUP_META_MISC}"
+
+# File resources are listed in the order that they are included in the .fw file
+# This is important, since this is the order that they're written on a firmware
+# update due to the event driven nature of the update system.
+file-resource bootloader.img {
+    host-path = "${FWUP_BOOTLOADER_IMG}"
+    skip-holes = false
+}
+file-resource rootfs.img {
+    host-path = "${FWUP_ROOTFS_IMG}"
+    skip-holes = false
+
+    # Error out if the rootfs size exceeds the partition size
+    assert-size-lte = ${ROOTFS_A_PART_COUNT}
+}
+
+mbr mbr-a {
+    partition 0 {
+        block-offset = ${BOOT_A_PART_OFFSET}
+        block-count = ${BOOT_A_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = ${ROOTFS_A_PART_OFFSET}
+        block-count = ${ROOTFS_A_PART_COUNT}
+        type = 0x83 # Linux
+    }
+    partition 2 {
+        block-offset = ${APP_PART_OFFSET}
+        block-count = ${APP_PART_COUNT}
+        type = 0x83 # Linux
+        expand = true
+    }
+    # partition 3 is unused
+}
+
+mbr mbr-b {
+    partition 0 {
+        block-offset = ${BOOT_B_PART_OFFSET}
+        block-count = ${BOOT_B_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = ${ROOTFS_B_PART_OFFSET}
+        block-count = ${ROOTFS_B_PART_COUNT}
+        type = 0x83 # Linux
+    }
+    partition 2 {
+        block-offset = ${APP_PART_OFFSET}
+        block-count = ${APP_PART_COUNT}
+        type = 0x83 # Linux
+        expand = true
+    }
+    # partition 3 is unused
+}
+
+# Location where installed firmware information is stored.
+# While this is called "u-boot", u-boot isn't involved in this
+# setup. It just provides a convenient key/value store format.
+uboot-environment uboot-env {
+    block-offset = ${UBOOT_ENV_OFFSET}
+    block-count = ${UBOOT_ENV_COUNT}
+}
+
+# This firmware task writes everything to the destination media
+task complete {
+    # Only match if not mounted
+    require-unmounted-destination = true
+
+    on-init {
+        mbr_write(mbr-a)
+
+        uboot_clearenv(uboot-env)
+
+        #uboot_setenv(uboot-env, "nerves_serial_number", "\${NERVES_SERIAL_NUMBER}")
+
+        uboot_setenv(uboot-env, "nerves_fw_active", "a")
+        uboot_setenv(uboot-env, "nerves_fw_devpath", ${NERVES_FW_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "a.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "a.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "a.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "a.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "a.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
+    }
+
+    on-resource bootloader.img {
+        raw_write(${BOOT_A_PART_OFFSET})
+    }
+
+    on-resource rootfs.img {
+        # write to the first rootfs partition
+        raw_write(${ROOTFS_A_PART_OFFSET})
+    }
+
+    on-finish {
+        # Clear out any old data in the B partition that might be mistaken for
+        # a file system. This is mostly to avoid confusion in humans when
+        # reprogramming SDCards with unknown contents.
+        raw_memset(${BOOT_B_PART_OFFSET}, 256, 0xff)
+        raw_memset(${ROOTFS_B_PART_OFFSET}, 256, 0xff)
+
+        # Invalidate the application data partition so that it is guaranteed to
+        # trigger the corrupt filesystem detection code on first boot and get
+        # formatted. If this isn't done and an old SDCard is reused, the
+        # application data could be in a weird state.
+        raw_memset(${APP_PART_OFFSET}, 256, 0xff)
+    }
+}
+
+task upgrade.a {
+    # This task upgrades the A partition
+    require-partition-offset(1, ${ROOTFS_B_PART_OFFSET})
+
+    # Verify the expected platform/architecture
+    require-uboot-variable(uboot-env, "b.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "b.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+
+    on-init {
+        info("Upgrading partition A")
+
+        # Clear some firmware information just in case this update gets
+        # interrupted midway. If this partition was bootable, it's not going to
+        # be soon.
+        uboot_unsetenv(uboot-env, "a.nerves_fw_version")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_platform")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_architecture")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_uuid")
+
+        # Reset the previous contents of the A boot partition
+        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
+        
+        # Indicate that the entire partition can be cleared
+        trim(${ROOTFS_A_PART_OFFSET}, ${ROOTFS_A_PART_COUNT})
+    }
+
+    # Write the new boot partition files and rootfs. The MBR still points
+    # to the B partition, so an error or power failure during this part
+    # won't hurt anything.
+    on-resource bootloader.img {
+        raw_write(${BOOT_A_PART_OFFSET})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
+    }
+
+    on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_B_PART_COUNT}
+        raw_write(${ROOTFS_A_PART_OFFSET})
+    }
+
+    on-finish {
+        # Update firmware metadata
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "a.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "a.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "a.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "a.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "a.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
+
+	    # Switch over to boot the new firmware
+        uboot_setenv(uboot-env, "nerves_fw_active", "a")
+        mbr_write(mbr-a)
+    }
+
+    on-error {
+    }
+}
+
+task upgrade.b {
+    # This task upgrades the B partition
+    require-partition-offset(1, ${ROOTFS_A_PART_OFFSET})
+
+    # Verify the expected platform/architecture
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+
+    on-init {
+        info("Upgrading partition B")
+
+        # Clear some firmware information just in case this update gets
+        # interrupted midway.
+        uboot_unsetenv(uboot-env, "b.nerves_fw_version")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_platform")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_architecture")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_uuid")
+
+        # Reset the previous contents of the B boot partition
+        fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})
+
+        trim(${ROOTFS_B_PART_OFFSET}, ${ROOTFS_B_PART_COUNT})
+    }
+
+    # Write the new boot partition files and rootfs. The MBR still points
+    # to the A partition, so an error or power failure during this part
+    # won't hurt anything.
+    on-resource bootloader.img {
+        raw_write(${BOOT_B_PART_OFFSET})
+        fat_setlabel(${BOOT_B_PART_OFFSET}, "BOOT-B")
+    }
+
+    on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_A_PART_COUNT}
+        raw_write(${ROOTFS_B_PART_OFFSET})
+    }
+
+    on-finish {
+        # Update firmware metadata
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "b.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "b.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "b.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "b.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "b.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "b.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "b.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "b.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "b.nerves_fw_uuid", "\${FWUP_META_UUID}")
+
+	# Switch over to boot the new firmware
+        uboot_setenv(uboot-env, "nerves_fw_active", "b")
+        mbr_write(mbr-b)
+    }
+
+    on-error {
+    }
+}
+
+task upgrade.unexpected {
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+    on-init {
+        error("Please check the media being upgraded. It doesn't look like either the A or B partitions are active.")
+    }
+}
+
+task upgrade.wrongplatform {
+    on-init {
+        error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
+    }
+}
+
+#task provision {
+#    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+#    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+#    on-init {
+#        include("${NERVES_PROVISIONING}")
+#    }
+#}
+#task provision.wrongplatform {
+#    on-init {
+#        error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
+#    }
+#}

--- a/recipes-devtools/fwup/fwup_git.bb
+++ b/recipes-devtools/fwup/fwup_git.bb
@@ -9,8 +9,8 @@ DEPENDS = "libconfuse libarchive libsodium zlib pkgconfig-native"
 SRC_URI = "git://github.com/fhunleth/fwup.git;protocol=https;branch=main;"
 
 # Modify these as desired
-PV = "1.9.1"
-SRCREV = "91fbf8cfd5eb92d6762eb49b6c0043c2410cac6c"
+PV = "1.10.1"
+SRCREV = "d458ccd83331d70510da7b16a207ce743c35c22a"
 
 S = "${WORKDIR}/git"
 

--- a/wic/sdimage-template.wks
+++ b/wic/sdimage-template.wks
@@ -1,0 +1,6 @@
+# short-description: Create two partitions Pi SD card image
+# long-description: Creates a partitioned SD card image with one boot partition
+# and one rootfs partition. Boot files are located in the first vfat partition.
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 100
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096


### PR DESCRIPTION
Hi there!

The YP supports many types of filesystem images with or without compression [3].

This PR introduces one more. The fwup type. So, a new bbclass to call the fwup tool with the right configuration is provided. That way, the user just need to provide the usual .fwup configuration file and bitbake does all hard work.

I provided some .fwup in fwup folder as example. But the user is in charge of create your own file.

1: https://docs.yoctoproject.org/ref-manual/classes.html?highlight=image_types#ref-classes-image-types
2: https://docs.yoctoproject.org/ref-manual/variables.html#term-IMAGE_FSTYPES
3: https://docs.yoctoproject.org/ref-manual/variables.html#term-IMAGE_TYPES

I also want to submit this layer to the layers index site here: https://layers.openembedded.org/layerindex/branch/master/layers/

But after that I want to suggest the creation of specific YP named release branches. For instance: one git branch for kirkstone, scarthgap and master branch. That way this layer better fits into expected YP/OE standards.

PS: I'm still testing my own PR. So far it's ready for use.
